### PR TITLE
Warn that need R >=3.1.2

### DIFF
--- a/_includes/rSetup.html
+++ b/_includes/rSetup.html
@@ -35,7 +35,12 @@
 	from <a href="http://cran.r-project.org/index.html">CRAN</a>. Or
 	you can use your package manager (e.g. for Debian/Ubuntu
 	run <code>sudo apt-get install r-base</code> and for Fedora run
-        <code>sudo yum install R</code>).  Also, please install the
+        <code>sudo yum install R</code>).  This workshop requires a version of
+        R no older than version 3.1.2; the default software repositories for
+        some Linux distributions (e.g. Ubuntu 14.04) only include older
+        versions, so if you are using one of these distributions it is
+        recommended you download binary files from CRAN instead.  Also, please
+        install the
 	<a href="http://www.rstudio.com/ide/download/desktop">RStudio IDE</a>.
       </p>
     </div>


### PR DESCRIPTION
The workshop uses `dplyr`, which requires R>=3.1.2, yet some distribution repos (e.g. the default Ubuntu 14.04 repo) only provide older versions of R.  Added note in rSetup that might need to use CRAN packages to get R>=3.1.2.