### PR TITLE
Link form index page to lesson 05 not working

### DIFF
--- a/index.md
+++ b/index.md
@@ -48,7 +48,7 @@ for each level and a very brief introduction to plotting.
 3. [Lesson 02 Starting with data](02-starting-with-data.html)
 4. [Lesson 03 Introducing `data.frame`](03-data-frames.html)
 5. [Lesson 04 Aggregating and analyzing data with dplyr](04-dplyr.html)
-6. [Lesson 05 Data visualisation with ggplot2](05-visualisation-ggplot2.html)
+6. [Lesson 05 Data visualization with ggplot2](05-visualization-ggplot2.html)
 7. [Lesson 06 R and SQL](06-r-and-sql.html)
 
 


### PR DESCRIPTION
Fix the link: http://www.datacarpentry.org/R-ecology/05-visualisation-ggplot2.html that was giving a 404 error to http://www.datacarpentry.org/R-ecology/05-visualization-ggplot2.html